### PR TITLE
Update deprecated set-output command

### DIFF
--- a/find_latest_tag.sh
+++ b/find_latest_tag.sh
@@ -24,4 +24,4 @@ if [ -z "${tag}" ]; then
     die "cannot find tag matching regex: ${2}"
 fi
 
-echo "::set-output name=tag::${tag}"
+echo "tag=${tag}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
@tdemin can you take a look? 🙏 

Fixes the following warning:

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/19969687/208312584-de4aac81-c2aa-4755-9fd1-e6b5dbaf1b5f.png">
